### PR TITLE
Fixed command in Day 10

### DIFF
--- a/day10.md
+++ b/day10.md
@@ -2,7 +2,7 @@
 
 Je veux savoir qui a commité sur un projet.
 
-    git shortlog -ns
+    git shortlog -n -s
 
 Vous renverra la liste des auteurs trié par leur nombre de commits.
 


### PR DESCRIPTION
Using git version 1.5.6.5,
    git shortlog -ns
displays nothing.

I updated the command to read;
    git shortlog -n -s
which works as described.
